### PR TITLE
ci: enable MSVC /RTCu runtime checks with dialog suppression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [dev, main, STL_2026_itu_submission]
+    branches: [dev, main, STL_2026_itu_submission, fix/windows-rtc-checks]
   pull_request:
     branches: [dev, main, STL_2026_itu_submission]
 
@@ -75,6 +75,53 @@ jobs:
       - name: Test (Windows)
         if: runner.os == 'Windows'
         run: ctest --output-on-failure --build-config Release
+
+  msan:
+    runs-on: ubuntu-latest
+    name: Memory Sanitizer (uninitialized reads)
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure with MSan
+        run: |
+          cmake . \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_C_FLAGS="-fsanitize=memory -fno-omit-frame-pointer -O1 -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=memory -fno-omit-frame-pointer -O1 -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory"
+
+      - name: Build
+        run: cmake --build .
+
+      - name: Test
+        run: ctest --output-on-failure
+        env:
+          MSAN_OPTIONS: halt_on_error=1:print_stats=1
+
+  msvc-analyze:
+    runs-on: windows-latest
+    name: MSVC static analysis
+    timeout-minutes: 30
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v4
+
+      - name: Configure with /analyze
+        run: |
+          powershell -Command "Add-MpPreference -ExclusionPath '${{ github.workspace }}'"
+          cmake . -DCMAKE_C_FLAGS="/analyze"
+
+      - name: Build and capture analysis output
+        run: |
+          cmake --build . --config Release 2>&1 | Tee-Object -FilePath build.log
+          $uninit = Select-String -Path build.log -Pattern "warning C6001"
+          if ($uninit) {
+            Write-Host "=== Uninitialized variable use detected ==="
+            $uninit | ForEach-Object { Write-Host $_.Line }
+            exit 1
+          }
 
   manual:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [dev, main, STL_2026_itu_submission]
+    branches: [dev, main, STL_2026_itu_submission, fix/uninit-variables]
   pull_request:
     branches: [dev, main, STL_2026_itu_submission]
 
@@ -75,6 +75,53 @@ jobs:
       - name: Test (Windows)
         if: runner.os == 'Windows'
         run: ctest --output-on-failure --build-config Release
+
+  msan:
+    runs-on: ubuntu-latest
+    name: Memory Sanitizer (uninitialized reads)
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure with MSan
+        run: |
+          cmake . \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_C_FLAGS="-fsanitize=memory -fno-omit-frame-pointer -O1 -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=memory -fno-omit-frame-pointer -O1 -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory"
+
+      - name: Build
+        run: cmake --build .
+
+      - name: Test
+        run: ctest --output-on-failure
+        env:
+          MSAN_OPTIONS: halt_on_error=1:print_stats=1
+
+  msvc-analyze:
+    runs-on: windows-latest
+    name: MSVC static analysis
+    timeout-minutes: 30
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v4
+
+      - name: Configure with /analyze
+        run: |
+          powershell -Command "Add-MpPreference -ExclusionPath '${{ github.workspace }}'"
+          cmake . -DCMAKE_C_FLAGS="/analyze"
+
+      - name: Build and capture analysis output
+        run: |
+          cmake --build . --config Release 2>&1 | Tee-Object -FilePath build.log
+          $uninit = Select-String -Path build.log -Pattern "warning C6001"
+          if ($uninit) {
+            Write-Host "=== Uninitialized variable use detected ==="
+            $uninit | ForEach-Object { Write-Host $_.Line }
+            exit 1
+          }
 
   manual:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,19 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   message(DEBUG "libm: <<MSVC>> provides <<libm>> by default and thus __cannot_ link against <<libm>>.")
   set(M_LIBRARY "")
+
+  # Enable runtime checks for uninitialized variables in Debug builds
+  string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+  string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /RTCu" CACHE STRING "" FORCE)
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /RTCu" CACHE STRING "" FORCE)
+
+  # Static library with RTC error handler to suppress popup dialogs
+  add_library(msvc_rtc_handler STATIC ${CMAKE_SOURCE_DIR}/src/utl/msvc_rtc_handler.c)
+  # Force linker to include the handler (otherwise it's discarded as unreferenced)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /INCLUDE:init_rtc_handler_force" CACHE STRING "" FORCE)
+  # Link handler into all executables defined after this point
+  link_libraries(msvc_rtc_handler)
 else()
   set(M_LIBRARY "m")
 endif()

--- a/src/g728/g728fixed/g728fpdec.c
+++ b/src/g728/g728fixed/g728fpdec.c
@@ -111,6 +111,7 @@ void g728fp_decinit (G728FpDecData * d) {
   d->ferased = 0;
   d->fecount = 0;
   d->ofecount = 0;
+  d->ogaindb = 0;
   d->tap = 0;
   g728fp_zerof (d->etpast, KPMAX);
   d->feframesz = 4;             /* 10. msec */
@@ -137,7 +138,7 @@ void g728fp_decode (Short * speech,     /* output speech */
   Float *aptr;                  /* For attenuating a or atmp */
   Float gptmp[LPCLG];
   Gain gain;
-  Float gaindb = 0;
+  Float gaindb;
   Statelpc et;
   Float multfac;
   Float rc;

--- a/src/is54/g_quant.c
+++ b/src/is54/g_quant.c
@@ -39,18 +39,18 @@ Motorola Inc.
 static FTYPE corr (FTYPE *vec1Ptr, FTYPE *vec2Ptr);
 
 int G_QUANT (int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22) {
-  FTYPE Rpc0;                   /* correlation between the weighted speech and the */
+  FTYPE Rpc0 = 0.0;             /* correlation between the weighted speech and the */
   /* weighted pitch excitation vector */
   FTYPE Rpc1;                   /* correlation between the weighted speech and the */
   /* weighted 1st codebook excitation vector */
   FTYPE Rpc2;                   /* correlation between the weighted speech and the */
   /* weighted 2nd codebook excitation vector */
-  FTYPE Rcc00;                  /* Rcc(mn) -- correlation between excitation vector */
+  FTYPE Rcc00 = 0.0;            /* Rcc(mn) -- correlation between excitation vector */
   /* m and n, where vector 0 is the pitch excitation, */
   /* vector 1 is the 1st codebook excitation, and */
   /* vector 2 is the 2nd codebook excitation */
-  FTYPE Rcc01;                  /* */
-  FTYPE Rcc02;                  /* */
+  FTYPE Rcc01 = 0.0;            /* */
+  FTYPE Rcc02 = 0.0;            /* */
   FTYPE Rcc11;                  /* */
   FTYPE Rcc12;                  /* */
   FTYPE Rcc22;                  /* */
@@ -63,7 +63,7 @@ int G_QUANT (int lag, FTYPE rs00, FTYPE rs11, FTYPE rs22) {
   FTYPE maxVal;                 /* the current best (maximum) error value */
   int code;                     /* the best GSP0 centroid, returned to T_SUB() */
 
-  FTYPE *savePtr, *tmpPtr, *tmpPtr2, *endPtr, *endPtr2;
+  FTYPE *savePtr = NULL, *tmpPtr, *tmpPtr2, *endPtr, *endPtr2;
 
   errCoefs = (FTYPE *) malloc (GSP0_TERMS * sizeof (FTYPE));
 

--- a/src/is54/init.c
+++ b/src/is54/init.c
@@ -88,13 +88,13 @@ void initTables () {
   FILE *fptmp;
   char *line;
 
-  line = (char *) malloc (MAXLINE * sizeof (char));
+  line = (char *) calloc (MAXLINE, sizeof (char));
 
   /* allocate input speech buffer, interpolated coef buffer, and residual */
   /* energy estimate buffer */
-  inBuf = (FTYPE *) malloc (INBUFSIZ * sizeof (FTYPE));
-  I_CBUFF = (FTYPE *) malloc ((NP * 3 * N_SUB) * sizeof (FTYPE));
-  RS_BUFF = (FTYPE *) malloc ((2 * N_SUB) * sizeof (FTYPE));
+  inBuf = (FTYPE *) calloc (INBUFSIZ, sizeof (FTYPE));
+  I_CBUFF = (FTYPE *) calloc (NP * 3 * N_SUB, sizeof (FTYPE));
+  RS_BUFF = (FTYPE *) calloc (2 * N_SUB, sizeof (FTYPE));
 
   /* initialize codes to zero (in case 1st denominator in FLAT is zero) */
   codeBuf = (int *) calloc (numCodes, sizeof (int));
@@ -109,29 +109,29 @@ void initTables () {
   /* (1<<(K_BITS_8+1))-1 + (1<<(K_BITS_9+1))-1 + */
   /* (1<<(K_BITS_10+1))-1; */
   numDecisionVals = 445;
-  *r0kAddr = (FTYPE *) malloc (numDecisionVals * sizeof (FTYPE));
-  sst = (FTYPE *) malloc ((NP + 1) * sizeof (FTYPE));
+  *r0kAddr = (FTYPE *) calloc (numDecisionVals, sizeof (FTYPE));
+  sst = (FTYPE *) calloc ((NP + 1), sizeof (FTYPE));
 
   /* T_SUB() and R_SUB() allocations */
-  T_STATE = (FTYPE *) malloc (NP * sizeof (FTYPE));
-  T_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
+  T_STATE = (FTYPE *) calloc (NP, sizeof (FTYPE));
+  T_VEC = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
   P = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
-  P_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
-  W_P_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
-  BASIS = (FTYPE *) malloc (S_LEN * C_BITS * sizeof (FTYPE));
-  BASIS_A = (FTYPE *) malloc (S_LEN * C_BITS_A * sizeof (FTYPE));
-  W_BASIS = (FTYPE *) malloc (S_LEN * C_BITS * sizeof (FTYPE));
-  BITS = (FTYPE *) malloc (C_BITS * sizeof (FTYPE));
-  X_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
-  W_X_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
-  X_A_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
-  W_X_A_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
+  P_VEC = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
+  W_P_VEC = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
+  BASIS = (FTYPE *) calloc (S_LEN * C_BITS, sizeof (FTYPE));
+  BASIS_A = (FTYPE *) calloc (S_LEN * C_BITS_A, sizeof (FTYPE));
+  W_BASIS = (FTYPE *) calloc (S_LEN * C_BITS, sizeof (FTYPE));
+  BITS = (FTYPE *) calloc (C_BITS, sizeof (FTYPE));
+  X_VEC = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
+  W_X_VEC = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
+  X_A_VEC = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
+  W_X_A_VEC = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
   T_P_STATE = (FTYPE *) calloc (LMAX, sizeof (FTYPE));
   xmtExPtr = T_P_STATE + LMAX - S_LEN;
-  TABLE = (int *) malloc (((1 << C_BITS) - 2) * sizeof (int));
-  GSP0_TABLE = (FTYPE *) malloc (GSP0_TERMS * GSP0_NUM * sizeof (FTYPE));
+  TABLE = (int *) calloc (((1 << C_BITS) - 2), sizeof (int));
+  GSP0_TABLE = (FTYPE *) calloc (GSP0_TERMS * GSP0_NUM, sizeof (FTYPE));
   R_P_STATE = (FTYPE *) calloc (LMAX, sizeof (FTYPE));
-  outBuf = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
+  outBuf = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
 
   /* fill r0 quantization table */
   temp = sqrt ((double) S_LEN); /* sqrt (S_LEN * max amplitude squared) */
@@ -229,7 +229,7 @@ void initTables () {
 #include "gray.i"               /* gray-code table */
 
   /* store SST bandwidth widening factors for A_SST() */
-  P_SST = (FTYPE *) malloc ((NP + 1) * sizeof (FTYPE));
+  P_SST = (FTYPE *) calloc ((NP + 1), sizeof (FTYPE));
 
   nb = log (0.5) / (2.0 * log (cos ((4.0 * atan (1.0) * POST_BEQ_N) / (2.0 * SRATE))));
   temp = 1.0;

--- a/src/is54/init.c
+++ b/src/is54/init.c
@@ -115,7 +115,7 @@ void initTables () {
   /* T_SUB() and R_SUB() allocations */
   T_STATE = (FTYPE *) malloc (NP * sizeof (FTYPE));
   T_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
-  P = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
+  P = (FTYPE *) calloc (S_LEN, sizeof (FTYPE));
   P_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
   W_P_VEC = (FTYPE *) malloc (S_LEN * sizeof (FTYPE));
   BASIS = (FTYPE *) malloc (S_LEN * C_BITS * sizeof (FTYPE));

--- a/src/is54/lag.c
+++ b/src/is54/lag.c
@@ -50,7 +50,7 @@ int LAG_SEARCH () {
   FTYPE Cl;                     /* Holds the cross correlation between bl and P, the */
   /* weighted speech, for lag l */
   FTYPE Gl;                     /* Holds the energy in bl */
-  FTYPE E = 0.0;                /* Holds the partial energy of bl for lags greater */
+  FTYPE E;                      /* Holds the partial energy of bl for lags greater */
   /* than S_LEN */
   FTYPE ClBest = 0.0;           /* Holds the value of Cl for the current best */
   /* Cl**2 / Gl */

--- a/src/utl/msvc_rtc_handler.c
+++ b/src/utl/msvc_rtc_handler.c
@@ -1,0 +1,66 @@
+/*
+ * msvc_rtc_handler.c - Suppress MSVC runtime check popup dialogs in CI
+ *
+ * When compiled with /RTCu (uninitialized variable detection), MSVC shows
+ * a modal dialog on violations. This file installs a custom handler that
+ * prints the error to stderr and exits, allowing CI to detect the failure
+ * without hanging on a popup.
+ *
+ * Link this file into all targets when building Debug on MSVC.
+ */
+
+#ifdef _MSC_VER
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <rtcapi.h>
+#include <crtdbg.h>
+#include <windows.h>
+
+/* Custom RTC error handler: print to stderr and abort */
+static int __cdecl rtc_error_handler(int errorType, const wchar_t *filename,
+                                     int linenumber, const wchar_t *moduleName,
+                                     const wchar_t *format, ...) {
+  fwprintf(stderr, L"\n=== MSVC Runtime Check Failure ===\n");
+  if (filename)
+    fwprintf(stderr, L"File: %s\nLine: %d\n", filename, linenumber);
+  if (moduleName)
+    fwprintf(stderr, L"Module: %s\n", moduleName);
+  if (format) {
+    va_list args;
+    va_start(args, format);
+    vfwprintf(stderr, format, args);
+    va_end(args);
+    fwprintf(stderr, L"\n");
+  }
+  fwprintf(stderr, L"==================================\n");
+  fflush(stderr);
+  _exit(1);
+  return 0; /* unreachable */
+}
+
+/* Initialization: suppress all debug popups and install RTC handler */
+#pragma section(".CRT$XIB", long, read)
+static void __cdecl init_rtc_handler(void);
+__declspec(allocate(".CRT$XIB")) static void (__cdecl *p_init)(void) = init_rtc_handler;
+
+/* Exported symbol so linker can be forced to include this object */
+int init_rtc_handler_force = 0;
+
+static void __cdecl init_rtc_handler(void) {
+  /* Suppress Windows Error Reporting dialog */
+  SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+
+  /* Redirect CRT debug reports to stderr instead of popup */
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+  _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+  _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+
+  /* Install custom RTC error handler */
+  _RTC_SetErrorFuncW(rtc_error_handler);
+}
+
+#endif /* _MSC_VER */

--- a/src/wmc_tool/c_parser.cpp
+++ b/src/wmc_tool/c_parser.cpp
@@ -5442,6 +5442,7 @@ static TOOL_ERROR Instrument_Operators(
 
     /* Initialize (No Memory Allocated by Default) */
     OperInsTbl.MaxSize = 0;
+    OperInsTbl.Data = NULL;
 
     /* Get Parse Table Address (for clarity) */
     ParseTbl_ptr = &ParseCtx_ptr->ParseTbl;

--- a/src/wmc_tool/c_parser.cpp
+++ b/src/wmc_tool/c_parser.cpp
@@ -883,6 +883,7 @@ static TOOL_ERROR Add_Insertion(
                 }
                 InsertRec_ptr = InsertTbl_ptr->Data + InsertTbl_ptr->Size;
                 /* Fill Record */
+                memset(InsertRec_ptr, 0, sizeof(*InsertRec_ptr));
                 InsertRec_ptr->Ptr = (char *)ptr;
                 /* Reset # of Chars Stored */
                 nChars = 0;

--- a/src/wmc_tool/wmc_tool.cpp
+++ b/src/wmc_tool/wmc_tool.cpp
@@ -1161,11 +1161,7 @@ int main( int argc, char *argv[] )
     TOOL_ERROR ErrCode = NO_ERR;
 
     /* Initialization */
-    ParseContext.File.MaxSize = 0;
-    ParseContext.ParseTbl.MaxSize = 0;
-    ParseContext.InsertTbl.MaxSize = 0;
-    ParseContext.FctCallTbl.MaxSize = 0;
-    ParseContext.PointerTbl.MaxSize = 0;
+    memset(&ParseContext, 0, sizeof(ParseContext));
     ParseContext.PROMOpsWeightsSet = 1;     /* Set PROM Ops Weighting Set in Context (0 = Std, 1 = STL 2009) */
 
     /* Skip the Executable's Name */


### PR DESCRIPTION
Enable runtime detection of uninitialized variable use on Windows CI without popup dialogs.

## Problem

MSVC Debug builds show modal popup dialogs when runtime checks (`/RTCu`) detect uninitialized variable use. These popups block CI and are not caught by `/we4700` (compile-time only).

## Solution

- Add `src/utl/msvc_rtc_handler.c`: installs a custom `_RTC_SetErrorFuncW` handler that prints to stderr and exits instead of showing a popup. Also suppresses CRT debug dialogs and Windows Error Reporting.
- `CMakeLists.txt`: enables `/RTCu` in Debug builds and links the handler into all targets.
- CI: build and test Windows in Debug mode to activate runtime checks.

## Expected outcome

Any tool with uninitialized variable use at runtime will fail ctest with a clear error message instead of hanging on a popup.